### PR TITLE
[codex] forward-port auto label parsing

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,18 +1,34 @@
-rules_version='2'
+rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /{document=**} {
-      // This rule allows anyone with your database reference to view, edit,
-      // and delete all data in your database. It is useful for getting
-      // started, but it is configured to expire after 30 days because it
-      // leaves your app open to attackers. At that time, all client
-      // requests to your database will be denied.
-      //
-      // Make sure to write security rules for your app before that time, or
-      // else all client requests to your database will be denied until you
-      // update your rules.
-      allow read, write: if request.time < timestamp.date(2025, 11, 3);
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    function isOwner(userId) {
+      return isSignedIn() && request.auth.uid == userId;
+    }
+
+    match /tasks/{taskId} {
+      allow create: if isOwner(request.resource.data.userId);
+      allow read, delete: if isOwner(resource.data.userId);
+      allow update: if isOwner(resource.data.userId) &&
+        request.resource.data.userId == resource.data.userId;
+    }
+
+    match /projects/{projectId} {
+      allow create: if isOwner(request.resource.data.userId);
+      allow read, delete: if isOwner(resource.data.userId);
+      allow update: if isOwner(resource.data.userId) &&
+        request.resource.data.userId == resource.data.userId;
+    }
+
+    match /labels/{labelId} {
+      allow create: if isOwner(request.resource.data.userId);
+      allow read, delete: if isOwner(resource.data.userId);
+      allow update: if isOwner(resource.data.userId) &&
+        request.resource.data.userId == resource.data.userId;
     }
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,12 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { onAuthStateChanged } from 'firebase/auth';
 import { auth } from './firebase/config';
 import { useAuthStore } from './store/authStore';
 import { useTaskStore } from './store/taskStore';
+import { useMobile } from './hooks/useMobile';
+import { taskService } from './services/taskService';
+import { projectService } from './services/projectService';
+import { labelService } from './services/labelService';
 import AuthForm from './components/auth/AuthForm';
 import Sidebar from './components/layout/Sidebar';
 import MainContent from './components/layout/MainContent';
@@ -10,89 +14,14 @@ import MainContent from './components/layout/MainContent';
 function App() {
   const { user, loading, setUser, setLoading } = useAuthStore();
   const { setTasks, setProjects, setLabels } = useTaskStore();
+  const { isMobile, sidebarOpen, toggleSidebar, closeSidebar } = useMobile();
+  const [dataReady, setDataReady] = useState({
+    tasks: false,
+    projects: false,
+    labels: false,
+  });
 
   useEffect(() => {
-    const loadUserData = async (userId: string) => {
-      // Mock data for now - will be replaced with Firebase queries
-      const mockTasks = [
-        {
-          id: '1',
-          title: 'Complete project proposal',
-          description: 'Write and submit the Q4 project proposal',
-          completed: false,
-          priority: 1 as const,
-          dueDate: new Date(),
-          createdAt: new Date(),
-          updatedAt: new Date(),
-          userId,
-          labels: ['work'],
-          subtasks: [],
-        },
-        {
-          id: '2',
-          title: 'Buy groceries',
-          description: 'Milk, bread, eggs, fruits',
-          completed: false,
-          priority: 3 as const,
-          dueDate: new Date(),
-          createdAt: new Date(),
-          updatedAt: new Date(),
-          userId,
-          labels: ['personal'],
-          subtasks: [],
-        },
-        {
-          id: '3',
-          title: 'Review team performance',
-          completed: true,
-          priority: 2 as const,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-          userId,
-          labels: ['work'],
-          subtasks: [],
-        },
-      ];
-
-      const mockProjects = [
-        {
-          id: '1',
-          name: 'Work Projects',
-          color: '#3b82f6',
-          userId,
-          createdAt: new Date(),
-          taskCount: 2,
-        },
-        {
-          id: '2',
-          name: 'Personal',
-          color: '#10b981',
-          userId,
-          createdAt: new Date(),
-          taskCount: 1,
-        },
-      ];
-
-      const mockLabels = [
-        {
-          id: '1',
-          name: 'work',
-          color: '#3b82f6',
-          userId,
-        },
-        {
-          id: '2',
-          name: 'personal',
-          color: '#10b981',
-          userId,
-        },
-      ];
-
-      setTasks(mockTasks);
-      setProjects(mockProjects);
-      setLabels(mockLabels);
-    };
-
     const unsubscribe = onAuthStateChanged(auth, (user) => {
       if (user) {
         setUser({
@@ -101,14 +30,16 @@ function App() {
           displayName: user.displayName || undefined,
           photoURL: user.photoURL || undefined,
         });
-        // Load user data here (tasks, projects, labels)
-        loadUserData(user.uid);
       } else {
         setUser(null);
-        // Clear data when user logs out
         setTasks([]);
         setProjects([]);
         setLabels([]);
+        setDataReady({
+          tasks: false,
+          projects: false,
+          labels: false,
+        });
       }
       setLoading(false);
     });
@@ -116,7 +47,42 @@ function App() {
     return () => unsubscribe();
   }, [setUser, setLoading, setTasks, setProjects, setLabels]);
 
-  if (loading) {
+  useEffect(() => {
+    if (!user) {
+      return;
+    }
+
+    setDataReady({
+      tasks: false,
+      projects: false,
+      labels: false,
+    });
+
+    const unsubscribeTasks = taskService.subscribeToUserTasks(user.uid, (tasks) => {
+      setTasks(tasks);
+      setDataReady((current) => (current.tasks ? current : { ...current, tasks: true }));
+    });
+
+    const unsubscribeProjects = projectService.subscribeToUserProjects(user.uid, (projects) => {
+      setProjects(projects);
+      setDataReady((current) => (current.projects ? current : { ...current, projects: true }));
+    });
+
+    const unsubscribeLabels = labelService.subscribeToUserLabels(user.uid, (labels) => {
+      setLabels(labels);
+      setDataReady((current) => (current.labels ? current : { ...current, labels: true }));
+    });
+
+    return () => {
+      unsubscribeTasks();
+      unsubscribeProjects();
+      unsubscribeLabels();
+    };
+  }, [user, setTasks, setProjects, setLabels]);
+
+  const allDataReady = user && dataReady.tasks && dataReady.projects && dataReady.labels;
+
+  if (loading || (user && !allDataReady)) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
@@ -129,9 +95,22 @@ function App() {
   }
 
   return (
-    <div className="flex h-screen bg-gray-50">
-      <Sidebar />
-      <MainContent />
+    <div className="safe-area-top safe-area-bottom flex h-screen bg-gray-50">
+      {isMobile && sidebarOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/50 lg:hidden"
+          onClick={closeSidebar}
+        />
+      )}
+      <Sidebar
+        isMobile={isMobile}
+        sidebarOpen={sidebarOpen}
+        closeSidebar={closeSidebar}
+      />
+      <MainContent
+        isMobile={isMobile}
+        toggleSidebar={toggleSidebar}
+      />
     </div>
   );
 }

--- a/src/components/layout/MainContent.tsx
+++ b/src/components/layout/MainContent.tsx
@@ -3,8 +3,14 @@ import TaskList from '../tasks/TaskList';
 import SearchBar from '../common/SearchBar';
 import ProfileDropdown from '../common/ProfileDropdown';
 import { format } from 'date-fns';
+import { Bars3Icon } from '@heroicons/react/24/outline';
 
-const MainContent = () => {
+interface MainContentProps {
+  isMobile: boolean;
+  toggleSidebar: () => void;
+}
+
+const MainContent = ({ isMobile, toggleSidebar }: MainContentProps) => {
   const { currentView, currentProjectId, currentLabelId, projects, labels } = useTaskStore();
 
   const getViewTitle = () => {
@@ -41,25 +47,32 @@ const MainContent = () => {
 
   return (
     <div className="flex-1 flex flex-col">
-      {/* Header */}
-      <div className="p-6 border-b border-gray-200 bg-white">
+      <div className="border-b border-gray-200 bg-white p-4 md:p-6">
         <div className="flex items-center justify-between mb-4">
-          <div>
-            <h1 className="text-2xl font-bold text-gray-900">{getViewTitle()}</h1>
-            {getViewSubtitle() && (
-              <p className="text-sm text-gray-500 mt-1">{getViewSubtitle()}</p>
+          <div className="flex items-center space-x-3">
+            {isMobile && (
+              <button
+                onClick={toggleSidebar}
+                className="rounded-lg p-2 hover:bg-gray-100 lg:hidden"
+              >
+                <Bars3Icon className="h-6 w-6 text-gray-500" />
+              </button>
             )}
+            <div>
+              <h1 className="text-xl font-bold text-gray-900 md:text-2xl">{getViewTitle()}</h1>
+              {getViewSubtitle() && (
+                <p className="mt-1 text-sm text-gray-500">{getViewSubtitle()}</p>
+              )}
+            </div>
           </div>
-          <div className="flex items-center space-x-4">
-            <div className="w-64">
+          <div className="flex items-center space-x-2 md:space-x-4">
+            <div className={isMobile ? 'w-40' : 'w-64'}>
               <SearchBar />
             </div>
             <ProfileDropdown />
           </div>
         </div>
       </div>
-
-      {/* Content */}
       <div className="flex-1 bg-gray-50">
         <TaskList />
       </div>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -10,9 +10,17 @@ import {
   PlusIcon,
   ChevronDownIcon,
   ChevronRightIcon,
+  XMarkIcon,
 } from '@heroicons/react/24/outline';
+import type { ViewType } from '../../types';
 
-const Sidebar = () => {
+interface SidebarProps {
+  isMobile: boolean;
+  sidebarOpen: boolean;
+  closeSidebar: () => void;
+}
+
+const Sidebar = ({ isMobile, sidebarOpen, closeSidebar }: SidebarProps) => {
   const { currentView, currentProjectId, currentLabelId, projects, labels, tasks, setCurrentView } = useTaskStore();
   const [isProjectsOpen, setIsProjectsOpen] = useState(true);
   const [isLabelsOpen, setIsLabelsOpen] = useState(false);
@@ -50,24 +58,47 @@ const Sidebar = () => {
     }
   };
 
+  const handleNavClick = (view: ViewType, id?: string) => {
+    setCurrentView(view, id);
+    if (isMobile) {
+      closeSidebar();
+    }
+  };
 
   return (
-    <div className="w-64 bg-gray-50 border-r border-gray-200 h-screen flex flex-col">
+    <div
+      className={`
+        ${isMobile
+          ? `fixed inset-y-0 left-0 z-50 w-64 transform transition-transform duration-300 ease-in-out ${
+              sidebarOpen ? 'translate-x-0' : '-translate-x-full'
+            }`
+          : 'w-64'}
+        flex h-screen flex-col border-r border-gray-200 bg-gray-50
+      `}
+    >
+      {isMobile && (
+        <div className="flex items-center justify-between border-b border-gray-200 p-4">
+          <h2 className="text-lg font-semibold text-gray-900">Menu</h2>
+          <button
+            onClick={closeSidebar}
+            className="rounded-lg p-2 hover:bg-gray-100"
+          >
+            <XMarkIcon className="h-6 w-6 text-gray-500" />
+          </button>
+        </div>
+      )}
 
-      {/* Quick Add */}
-      <div className="p-4 border-b border-gray-200 mt-4">
+      <div className={`border-b border-gray-200 p-4 ${isMobile ? '' : 'mt-4'}`}>
         <button className="w-full flex items-center space-x-2 text-red-500 hover:bg-red-50 rounded-lg p-2">
           <PlusIcon className="w-5 h-5" />
           <span className="font-medium">Add task</span>
         </button>
       </div>
 
-      {/* Main Navigation */}
       <div className="flex-1 overflow-y-auto">
         <nav className="p-2 space-y-1">
-          {/* Inbox */}
           <button
-            onClick={() => setCurrentView('inbox')}
+            onClick={() => handleNavClick('inbox')}
             className={`w-full flex items-center justify-between p-2 rounded-lg hover:bg-gray-100 ${
               currentView === 'inbox' ? 'bg-red-50 text-red-700' : 'text-gray-700'
             }`}
@@ -79,9 +110,8 @@ const Sidebar = () => {
             <span className="text-sm text-gray-500">{getTaskCount('inbox')}</span>
           </button>
 
-          {/* Today */}
           <button
-            onClick={() => setCurrentView('today')}
+            onClick={() => handleNavClick('today')}
             className={`w-full flex items-center justify-between p-2 rounded-lg hover:bg-gray-100 ${
               currentView === 'today' ? 'bg-red-50 text-red-700' : 'text-gray-700'
             }`}
@@ -93,9 +123,8 @@ const Sidebar = () => {
             <span className="text-sm text-gray-500">{getTaskCount('today')}</span>
           </button>
 
-          {/* Upcoming */}
           <button
-            onClick={() => setCurrentView('upcoming')}
+            onClick={() => handleNavClick('upcoming')}
             className={`w-full flex items-center justify-between p-2 rounded-lg hover:bg-gray-100 ${
               currentView === 'upcoming' ? 'bg-red-50 text-red-700' : 'text-gray-700'
             }`}
@@ -108,7 +137,6 @@ const Sidebar = () => {
           </button>
         </nav>
 
-        {/* Projects Section */}
         <div className="p-2 mt-4">
           <button
             onClick={() => setIsProjectsOpen(!isProjectsOpen)}
@@ -136,7 +164,7 @@ const Sidebar = () => {
               {projects.map((project) => (
                 <button
                   key={project.id}
-                  onClick={() => setCurrentView('project', project.id)}
+                  onClick={() => handleNavClick('project', project.id)}
                   className={`w-full flex items-center justify-between p-2 rounded-lg hover:bg-gray-100 ${
                     currentView === 'project' && currentProjectId === project.id
                       ? 'bg-red-50 text-red-700'
@@ -159,7 +187,6 @@ const Sidebar = () => {
           )}
         </div>
 
-        {/* Labels Section */}
         <div className="p-2">
           <button
             onClick={() => setIsLabelsOpen(!isLabelsOpen)}
@@ -187,7 +214,7 @@ const Sidebar = () => {
               {labels.map((label) => (
                 <button
                   key={label.id}
-                  onClick={() => setCurrentView('label', label.id)}
+                  onClick={() => handleNavClick('label', label.id)}
                   className={`w-full flex items-center justify-between p-2 rounded-lg hover:bg-gray-100 ${
                     currentView === 'label' && currentLabelId === label.id
                       ? 'bg-red-50 text-red-700'
@@ -208,7 +235,6 @@ const Sidebar = () => {
         </div>
       </div>
 
-      {/* Modals */}
       <ProjectForm 
         isOpen={showProjectForm} 
         onClose={() => setShowProjectForm(false)} 

--- a/src/components/tasks/ParsedInputDisplay.tsx
+++ b/src/components/tasks/ParsedInputDisplay.tsx
@@ -1,0 +1,106 @@
+import { CalendarIcon, FlagIcon, TagIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import type { ParsedInput } from '../../utils/taskInputParser';
+
+interface ParsedInputDisplayProps {
+  parsedInput: ParsedInput;
+  onRemovePriority: () => void;
+  onRemoveDate: () => void;
+  onRemoveLabel: (label: string) => void;
+}
+
+const ParsedInputDisplay = ({
+  parsedInput,
+  onRemovePriority,
+  onRemoveDate,
+  onRemoveLabel,
+}: ParsedInputDisplayProps) => {
+  const { priority, dueDate, labels } = parsedInput;
+
+  if (!priority && !dueDate && labels.length === 0) {
+    return null;
+  }
+
+  const formatDate = (date: Date) => {
+    const today = new Date();
+    const tomorrow = new Date(today);
+    tomorrow.setDate(today.getDate() + 1);
+
+    if (date.toDateString() === today.toDateString()) {
+      return 'Today';
+    }
+
+    if (date.toDateString() === tomorrow.toDateString()) {
+      return 'Tomorrow';
+    }
+
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: date.getFullYear() !== today.getFullYear() ? 'numeric' : undefined,
+    });
+  };
+
+  const getPriorityColor = (value: number) => {
+    switch (value) {
+      case 1:
+        return 'bg-red-100 text-red-800 border-red-200';
+      case 2:
+        return 'bg-orange-100 text-orange-800 border-orange-200';
+      case 3:
+        return 'bg-yellow-100 text-yellow-800 border-yellow-200';
+      default:
+        return 'bg-gray-100 text-gray-800 border-gray-200';
+    }
+  };
+
+  return (
+    <div className="mt-2 mb-3 flex flex-wrap gap-2">
+      {priority && (
+        <div className={`inline-flex items-center rounded-md border px-2 py-1 text-xs font-medium ${getPriorityColor(priority)}`}>
+          <FlagIcon className="mr-1 h-3 w-3" />
+          <span>Priority {priority}</span>
+          <button
+            type="button"
+            onClick={onRemovePriority}
+            className="ml-1 rounded-full p-0.5 hover:bg-black/10"
+          >
+            <XMarkIcon className="h-3 w-3" />
+          </button>
+        </div>
+      )}
+
+      {dueDate && (
+        <div className="inline-flex items-center rounded-md border border-blue-200 bg-blue-100 px-2 py-1 text-xs font-medium text-blue-800">
+          <CalendarIcon className="mr-1 h-3 w-3" />
+          <span>{formatDate(dueDate)}</span>
+          <button
+            type="button"
+            onClick={onRemoveDate}
+            className="ml-1 rounded-full p-0.5 hover:bg-black/10"
+          >
+            <XMarkIcon className="h-3 w-3" />
+          </button>
+        </div>
+      )}
+
+      {labels.map((label) => (
+        <div
+          key={label}
+          className="inline-flex items-center rounded-md border border-purple-200 bg-purple-100 px-2 py-1 text-xs font-medium text-purple-800"
+        >
+          <TagIcon className="mr-1 h-3 w-3" />
+          <span>{label}</span>
+          <button
+            type="button"
+            onClick={() => onRemoveLabel(label)}
+            className="ml-1 rounded-full p-0.5 hover:bg-black/10"
+          >
+            <XMarkIcon className="h-3 w-3" />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ParsedInputDisplay;

--- a/src/components/tasks/TaskForm.tsx
+++ b/src/components/tasks/TaskForm.tsx
@@ -1,39 +1,92 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTaskStore } from '../../store/taskStore';
 import { useAuthStore } from '../../store/authStore';
 import { PlusIcon, CalendarIcon, FlagIcon } from '@heroicons/react/24/outline';
 import type { Task } from '../../types';
+import { taskInputParser, type ParsedInput } from '../../utils/taskInputParser';
+import ParsedInputDisplay from './ParsedInputDisplay';
 
 const TaskForm = () => {
   const { user } = useAuthStore();
-  const { addTask, currentView, currentProjectId } = useTaskStore();
+  const { addTask, currentView, currentProjectId, findOrCreateLabel } = useTaskStore();
   const [isExpanded, setIsExpanded] = useState(false);
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [dueDate, setDueDate] = useState('');
   const [priority, setPriority] = useState<1 | 2 | 3 | 4>(4);
+  const [parsedInput, setParsedInput] = useState<ParsedInput | null>(null);
+  const [overriddenValues, setOverriddenValues] = useState<{
+    priority?: boolean;
+    date?: boolean;
+    labels?: string[];
+  }>({});
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!title.trim() || !user) return;
+  const getEffectiveParsedInput = (): ParsedInput | null => {
+    if (!parsedInput) {
+      return null;
+    }
+
+    return {
+      ...parsedInput,
+      priority: overriddenValues.priority ? undefined : parsedInput.priority,
+      dueDate: overriddenValues.date ? undefined : parsedInput.dueDate,
+      labels: parsedInput.labels.filter((label) => !overriddenValues.labels?.includes(label)),
+    };
+  };
+
+  useEffect(() => {
+    if (title.trim()) {
+      setParsedInput(taskInputParser.parseInput(title));
+    } else {
+      setParsedInput(null);
+    }
+  }, [title]);
+
+  const submitTask = async () => {
+    if (!user) {
+      return;
+    }
+
+    const effectiveParsedInput = getEffectiveParsedInput();
+    const finalTitle = effectiveParsedInput?.cleanTitle.trim() || title.trim();
+    if (!finalTitle) {
+      return;
+    }
+
+    let finalLabels: string[] = [];
+    if (effectiveParsedInput?.labels.length) {
+      const createdLabels = await Promise.all(
+        effectiveParsedInput.labels.map((labelName) => findOrCreateLabel(labelName, user.uid))
+      );
+      finalLabels = createdLabels.map((label) => label.id);
+    }
 
     const newTask: Task = {
       id: crypto.randomUUID(),
-      title: title.trim(),
+      title: finalTitle,
       description: description.trim() || undefined,
       completed: false,
-      priority,
-      dueDate: dueDate ? new Date(dueDate) : undefined,
+      priority: effectiveParsedInput?.priority ?? priority,
+      dueDate: effectiveParsedInput?.dueDate ?? (dueDate ? new Date(dueDate) : undefined),
       createdAt: new Date(),
       updatedAt: new Date(),
       userId: user.uid,
       projectId: currentView === 'project' ? currentProjectId : undefined,
-      labels: [],
+      labels: finalLabels,
       subtasks: [],
     };
 
-    addTask(newTask);
+    const sanitizedTask = Object.fromEntries(
+      Object.entries(newTask).filter(([, value]) => value !== undefined)
+    ) as Task;
+
+    await addTask(sanitizedTask);
     resetForm();
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await submitTask();
   };
 
   const resetForm = () => {
@@ -48,15 +101,21 @@ const TaskForm = () => {
     resetForm();
   };
 
+  const handleKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      await submitTask();
+    }
+  };
 
   if (!isExpanded) {
     return (
       <button
         onClick={() => setIsExpanded(true)}
-        className="w-full flex items-center space-x-3 p-4 bg-white border border-gray-200 rounded-lg hover:shadow-md transition-all duration-200 group"
+        className="group w-full flex items-center space-x-3 rounded-lg border border-gray-200 bg-white p-3 transition-all duration-200 hover:shadow-md md:p-4"
       >
         <PlusIcon className="w-5 h-5 text-red-500" />
-        <span className="text-gray-500 group-hover:text-gray-700">
+        <span className="text-sm text-gray-500 group-hover:text-gray-700 md:text-base">
           Add task
         </span>
       </button>
@@ -64,46 +123,56 @@ const TaskForm = () => {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="bg-white border border-gray-200 rounded-lg p-4 shadow-md">
-      {/* Title Input */}
+    <form onSubmit={handleSubmit} className="rounded-lg border border-gray-200 bg-white p-3 shadow-md md:p-4">
       <input
         type="text"
         value={title}
         onChange={(e) => setTitle(e.target.value)}
-        placeholder="Task name"
-        className="w-full text-sm font-medium border-none outline-none placeholder-gray-400 mb-2"
+        onKeyDown={handleKeyDown}
+        placeholder="Task name (try: p1 today @work fix bug)"
+        className="mb-2 min-h-[44px] w-full border-none text-sm font-medium outline-none placeholder-gray-400 md:text-base"
         autoFocus
       />
 
-      {/* Description Input */}
+      {getEffectiveParsedInput() && (
+        <ParsedInputDisplay
+          parsedInput={getEffectiveParsedInput()!}
+          onRemovePriority={() => setOverriddenValues((current) => ({ ...current, priority: true }))}
+          onRemoveDate={() => setOverriddenValues((current) => ({ ...current, date: true }))}
+          onRemoveLabel={(labelName) =>
+            setOverriddenValues((current) => ({
+              ...current,
+              labels: [...(current.labels || []), labelName],
+            }))
+          }
+        />
+      )}
+
       <textarea
         value={description}
         onChange={(e) => setDescription(e.target.value)}
         placeholder="Description"
         rows={2}
-        className="w-full text-sm border-none outline-none placeholder-gray-400 resize-none mb-3"
+        className="mb-3 min-h-[44px] w-full resize-none border-none text-sm outline-none placeholder-gray-400 md:text-base"
       />
 
-      {/* Task Options */}
-      <div className="flex items-center space-x-4 mb-4">
-        {/* Due Date */}
+      <div className="mb-4 flex flex-col space-y-3 sm:flex-row sm:items-center sm:space-x-4 sm:space-y-0">
         <div className="flex items-center space-x-2">
-          <CalendarIcon className="w-4 h-4 text-gray-400" />
+          <CalendarIcon className="h-5 w-5 text-gray-400" />
           <input
             type="date"
             value={dueDate}
             onChange={(e) => setDueDate(e.target.value)}
-            className="text-xs border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="min-h-[44px] rounded border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
         </div>
 
-        {/* Priority */}
         <div className="flex items-center space-x-2">
-          <FlagIcon className="w-4 h-4 text-gray-400" />
+          <FlagIcon className="h-5 w-5 text-gray-400" />
           <select
             value={priority}
             onChange={(e) => setPriority(Number(e.target.value) as 1 | 2 | 3 | 4)}
-            className="text-xs border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="min-h-[44px] rounded border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
           >
             <option value={4}>Priority 4</option>
             <option value={3}>Priority 3</option>
@@ -113,19 +182,18 @@ const TaskForm = () => {
         </div>
       </div>
 
-      {/* Action Buttons */}
-      <div className="flex items-center justify-end space-x-2">
+      <div className="flex items-center justify-end space-x-3">
         <button
           type="button"
           onClick={handleCancel}
-          className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800 rounded border border-gray-300 hover:bg-gray-50"
+          className="min-h-[44px] rounded border border-gray-300 px-4 py-2.5 text-sm text-gray-600 hover:bg-gray-50 hover:text-gray-800"
         >
           Cancel
         </button>
         <button
           type="submit"
-          disabled={!title.trim()}
-          className="px-3 py-1.5 text-sm text-white bg-red-500 hover:bg-red-600 disabled:opacity-50 disabled:cursor-not-allowed rounded"
+          disabled={!title.trim() && !parsedInput?.cleanTitle.trim()}
+          className="min-h-[44px] rounded bg-red-500 px-4 py-2.5 text-sm text-white hover:bg-red-600 disabled:cursor-not-allowed disabled:opacity-50"
         >
           Add task
         </button>

--- a/src/components/tasks/TaskItem.tsx
+++ b/src/components/tasks/TaskItem.tsx
@@ -16,22 +16,22 @@ interface TaskItemProps {
 }
 
 const TaskItem = ({ task }: TaskItemProps) => {
-  const { updateTask, deleteTask } = useTaskStore();
+  const { updateTask, deleteTask, labels } = useTaskStore();
   const [isEditing, setIsEditing] = useState(false);
   const [editTitle, setEditTitle] = useState(task.title);
 
-  const handleToggleComplete = () => {
-    updateTask(task.id, { 
+  const handleToggleComplete = async () => {
+    await updateTask(task.id, {
       completed: !task.completed,
-      updatedAt: new Date()
+      updatedAt: new Date(),
     });
   };
 
-  const handleSaveEdit = () => {
+  const handleSaveEdit = async () => {
     if (editTitle.trim()) {
-      updateTask(task.id, { 
+      await updateTask(task.id, {
         title: editTitle.trim(),
-        updatedAt: new Date()
+        updatedAt: new Date(),
       });
     } else {
       setEditTitle(task.title);
@@ -39,9 +39,9 @@ const TaskItem = ({ task }: TaskItemProps) => {
     setIsEditing(false);
   };
 
-  const handleKeyPress = (e: React.KeyboardEvent) => {
+  const handleKeyPress = async (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
-      handleSaveEdit();
+      await handleSaveEdit();
     } else if (e.key === 'Escape') {
       setEditTitle(task.title);
       setIsEditing(false);
@@ -82,7 +82,7 @@ const TaskItem = ({ task }: TaskItemProps) => {
 
   return (
     <div
-      className={`group bg-white border border-gray-200 rounded-lg p-4 hover:shadow-md transition-all duration-200 border-l-4 ${getPriorityBorder(
+      className={`group bg-white border border-gray-200 rounded-lg p-3 md:p-4 hover:shadow-md transition-all duration-200 border-l-4 ${getPriorityBorder(
         task.priority
       )} ${task.completed ? 'opacity-60' : ''}`}
     >
@@ -90,12 +90,12 @@ const TaskItem = ({ task }: TaskItemProps) => {
         {/* Checkbox */}
         <button
           onClick={handleToggleComplete}
-          className="flex-shrink-0 mt-0.5"
+          className="flex-shrink-0 mt-0.5 p-1 touch-manipulation"
         >
           {task.completed ? (
-            <CheckCircleFilledIcon className="w-6 h-6 text-green-500" />
+            <CheckCircleFilledIcon className="w-6 h-6 text-green-500 md:w-7 md:h-7" />
           ) : (
-            <CheckCircleIcon className="w-6 h-6 text-gray-400 hover:text-green-500" />
+            <CheckCircleIcon className="w-6 h-6 text-gray-400 hover:text-green-500 md:w-7 md:h-7" />
           )}
         </button>
 
@@ -108,14 +108,14 @@ const TaskItem = ({ task }: TaskItemProps) => {
               onChange={(e) => setEditTitle(e.target.value)}
               onBlur={handleSaveEdit}
               onKeyDown={handleKeyPress}
-              className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="min-h-[44px] w-full rounded border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 md:text-base"
               autoFocus
             />
           ) : (
             <h3
-              className={`text-sm font-medium ${
+              className={`-my-2 cursor-pointer py-2 text-sm font-medium touch-manipulation md:text-base ${
                 task.completed ? 'line-through text-gray-500' : 'text-gray-900'
-              } cursor-pointer`}
+              }`}
               onClick={() => setIsEditing(true)}
             >
               {task.title}
@@ -123,12 +123,10 @@ const TaskItem = ({ task }: TaskItemProps) => {
           )}
 
           {task.description && (
-            <p className="text-xs text-gray-500 mt-1">{task.description}</p>
+            <p className="mt-1 text-xs text-gray-500 md:text-sm">{task.description}</p>
           )}
 
-          {/* Task Meta */}
-          <div className="flex items-center space-x-4 mt-2">
-            {/* Priority */}
+          <div className="mt-2 flex flex-wrap items-center gap-3 md:gap-4">
             {task.priority < 4 && (
               <div className="flex items-center space-x-1">
                 <FlagIcon className={`w-4 h-4 ${getPriorityColor(task.priority)}`} />
@@ -138,7 +136,6 @@ const TaskItem = ({ task }: TaskItemProps) => {
               </div>
             )}
 
-            {/* Due Date */}
             {task.dueDate && (
               <div className="flex items-center space-x-1">
                 <CalendarIcon className="w-4 h-4 text-gray-400" />
@@ -148,17 +145,19 @@ const TaskItem = ({ task }: TaskItemProps) => {
               </div>
             )}
 
-            {/* Labels */}
-            {task.labels.length > 0 && (
+            {task.labels.length > 0 && labels.length > 0 && (
               <div className="flex items-center space-x-1">
-                {task.labels.slice(0, 2).map((label, index) => (
-                  <span
-                    key={index}
-                    className="inline-block px-2 py-1 text-xs bg-gray-100 text-gray-600 rounded"
-                  >
-                    {label}
-                  </span>
-                ))}
+                {task.labels.slice(0, 2).map((labelId, index) => {
+                  const label = labels.find((currentLabel) => currentLabel.id === labelId);
+                  return (
+                    <span
+                      key={index}
+                      className="inline-block rounded bg-gray-100 px-2 py-1 text-xs text-gray-600"
+                    >
+                      {label?.name || labelId}
+                    </span>
+                  );
+                })}
                 {task.labels.length > 2 && (
                   <span className="text-xs text-gray-400">
                     +{task.labels.length - 2}
@@ -169,26 +168,26 @@ const TaskItem = ({ task }: TaskItemProps) => {
           </div>
         </div>
 
-        {/* Actions */}
-        <div className="flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+        <div className="flex-shrink-0 transition-opacity md:opacity-0 md:group-hover:opacity-100">
           <div className="flex items-center space-x-1">
             <button
               onClick={() => setIsEditing(true)}
-              className="p-1 text-gray-400 hover:text-gray-600 rounded"
+              className="rounded p-2 text-gray-400 hover:text-gray-600 touch-manipulation"
             >
-              <PencilIcon className="w-4 h-4" />
+              <PencilIcon className="h-5 w-5 md:h-4 md:w-4" />
             </button>
             <button
-              onClick={() => deleteTask(task.id)}
-              className="p-1 text-gray-400 hover:text-red-500 rounded"
+              onClick={async () => {
+                await deleteTask(task.id);
+              }}
+              className="rounded p-2 text-gray-400 hover:text-red-500 touch-manipulation"
             >
-              <TrashIcon className="w-4 h-4" />
+              <TrashIcon className="h-5 w-5 md:h-4 md:w-4" />
             </button>
           </div>
         </div>
       </div>
 
-      {/* Subtasks */}
       {task.subtasks.length > 0 && (
         <div className="ml-9 mt-3 space-y-2">
           {task.subtasks.map((subtask) => (

--- a/src/components/tasks/TaskList.tsx
+++ b/src/components/tasks/TaskList.tsx
@@ -98,12 +98,10 @@ const TaskList = () => {
   }
 
   return (
-    <div className="p-6">
-      {/* Quick Add Form */}
+    <div className="p-4 md:p-6">
       <TaskForm />
       
-      {/* Tasks */}
-      <div className="mt-6 space-y-2">
+      <div className="mt-4 space-y-3 md:mt-6 md:space-y-2">
         {filteredTasks.length === 0 ? (
           <div className="text-center py-12">
             <div className="text-gray-400 text-lg mb-2">

--- a/src/config/parserConfig.ts
+++ b/src/config/parserConfig.ts
@@ -1,0 +1,145 @@
+export interface ParserConfig {
+  priority: {
+    keywords: Record<string, number>;
+    pattern: RegExp;
+  };
+  dates: {
+    keywords: Record<string, () => Date | null>;
+    patterns: Array<{
+      regex: RegExp;
+      parser: (match: RegExpMatchArray) => Date | null;
+    }>;
+  };
+  labels: {
+    pattern: RegExp;
+    defaultColor: string;
+  };
+}
+
+const getToday = () => new Date();
+
+const getTomorrow = () => {
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  return tomorrow;
+};
+
+const getNextWeek = () => {
+  const nextWeek = new Date();
+  nextWeek.setDate(nextWeek.getDate() + 7);
+  return nextWeek;
+};
+
+const getDayOfWeek = (dayName: string) => {
+  const today = new Date();
+  const days = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+  const targetDay = days.indexOf(dayName.toLowerCase());
+
+  if (targetDay === -1) {
+    return null;
+  }
+
+  const daysUntilTarget = (targetDay - today.getDay() + 7) % 7;
+  const targetDate = new Date(today);
+  targetDate.setDate(today.getDate() + (daysUntilTarget === 0 ? 7 : daysUntilTarget));
+
+  return targetDate;
+};
+
+export const parserConfig: ParserConfig = {
+  priority: {
+    keywords: {
+      p1: 1,
+      p2: 2,
+      p3: 3,
+      p4: 4,
+      'priority 1': 1,
+      'priority 2': 2,
+      'priority 3': 3,
+      'priority 4': 4,
+      high: 1,
+      medium: 2,
+      low: 3,
+      urgent: 1,
+    },
+    pattern: /\b(p[1-4]|priority [1-4]|high|medium|low|urgent)\b/gi,
+  },
+  dates: {
+    keywords: {
+      today: getToday,
+      tod: getToday,
+      tomorrow: getTomorrow,
+      tom: getTomorrow,
+      tmr: getTomorrow,
+      tmrw: getTomorrow,
+      'next week': getNextWeek,
+      monday: () => getDayOfWeek('monday'),
+      tuesday: () => getDayOfWeek('tuesday'),
+      wednesday: () => getDayOfWeek('wednesday'),
+      thursday: () => getDayOfWeek('thursday'),
+      friday: () => getDayOfWeek('friday'),
+      saturday: () => getDayOfWeek('saturday'),
+      sunday: () => getDayOfWeek('sunday'),
+      mon: () => getDayOfWeek('monday'),
+      tue: () => getDayOfWeek('tuesday'),
+      wed: () => getDayOfWeek('wednesday'),
+      thu: () => getDayOfWeek('thursday'),
+      fri: () => getDayOfWeek('friday'),
+      sat: () => getDayOfWeek('saturday'),
+      sun: () => getDayOfWeek('sunday'),
+    },
+    patterns: [
+      {
+        regex: /\b(\d{1,2})\/(\d{1,2})\/(\d{4})\b/g,
+        parser: (match) => {
+          const [, month, day, year] = match;
+          const date = new Date(parseInt(year, 10), parseInt(month, 10) - 1, parseInt(day, 10));
+          return Number.isNaN(date.getTime()) ? null : date;
+        },
+      },
+      {
+        regex: /\b(\d{1,2})\/(\d{1,2})\/(\d{2})\b/g,
+        parser: (match) => {
+          const [, month, day, year] = match;
+          const fullYear = 2000 + parseInt(year, 10);
+          const date = new Date(fullYear, parseInt(month, 10) - 1, parseInt(day, 10));
+          return Number.isNaN(date.getTime()) ? null : date;
+        },
+      },
+      {
+        regex: /\b(\d{1,2})\/(\d{1,2})\b/g,
+        parser: (match) => {
+          const [, month, day] = match;
+          const monthNumber = parseInt(month, 10);
+          const dayNumber = parseInt(day, 10);
+
+          if (monthNumber < 1 || monthNumber > 12 || dayNumber < 1 || dayNumber > 31) {
+            return null;
+          }
+
+          const today = new Date();
+          const currentYear = today.getFullYear();
+          const parsedDate = new Date(currentYear, monthNumber - 1, dayNumber);
+
+          if (parsedDate < today) {
+            parsedDate.setFullYear(currentYear + 1);
+          }
+
+          return Number.isNaN(parsedDate.getTime()) ? null : parsedDate;
+        },
+      },
+      {
+        regex: /\b(\d{4})-(\d{1,2})-(\d{1,2})\b/g,
+        parser: (match) => {
+          const [, year, month, day] = match;
+          const date = new Date(parseInt(year, 10), parseInt(month, 10) - 1, parseInt(day, 10));
+          return Number.isNaN(date.getTime()) ? null : date;
+        },
+      },
+    ],
+  },
+  labels: {
+    pattern: /@(\w+)/g,
+    defaultColor: '#6366f1',
+  },
+};

--- a/src/hooks/useMobile.ts
+++ b/src/hooks/useMobile.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+export const useMobile = (breakpoint: number = 768) => {
+  const [isMobile, setIsMobile] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  useEffect(() => {
+    const checkIsMobile = () => {
+      const nextIsMobile = window.innerWidth < breakpoint;
+      setIsMobile(nextIsMobile);
+
+      if (!nextIsMobile) {
+        setSidebarOpen(false);
+      }
+    };
+
+    checkIsMobile();
+    window.addEventListener('resize', checkIsMobile);
+
+    return () => window.removeEventListener('resize', checkIsMobile);
+  }, [breakpoint]);
+
+  return {
+    isMobile,
+    sidebarOpen,
+    toggleSidebar: () => setSidebarOpen((open) => !open),
+    closeSidebar: () => setSidebarOpen(false),
+  };
+};

--- a/src/index.css
+++ b/src/index.css
@@ -6,4 +6,38 @@
 
 body {
   font-family: 'Inter', system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+@layer base {
+  input,
+  button,
+  select,
+  textarea {
+    @apply touch-manipulation;
+  }
+
+  input[type="text"],
+  input[type="email"],
+  input[type="password"],
+  input[type="date"],
+  select,
+  textarea {
+    font-size: 16px;
+  }
+
+  * {
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
+@layer utilities {
+  .safe-area-top {
+    padding-top: env(safe-area-inset-top);
+  }
+
+  .safe-area-bottom {
+    padding-bottom: env(safe-area-inset-bottom);
+  }
 }

--- a/src/store/taskStore.ts
+++ b/src/store/taskStore.ts
@@ -1,5 +1,8 @@
 import { create } from 'zustand';
 import type { Task, Project, Label, TaskFilter, ViewType } from '../types';
+import { labelService } from '../services/labelService';
+import { taskService } from '../services/taskService';
+import { parserConfig } from '../config/parserConfig';
 
 interface TaskState {
   tasks: Task[];
@@ -13,9 +16,9 @@ interface TaskState {
   
   // Actions
   setTasks: (tasks: Task[]) => void;
-  addTask: (task: Task) => void;
-  updateTask: (taskId: string, updates: Partial<Task>) => void;
-  deleteTask: (taskId: string) => void;
+  addTask: (task: Task) => Promise<void>;
+  updateTask: (taskId: string, updates: Partial<Task>) => Promise<void>;
+  deleteTask: (taskId: string) => Promise<void>;
   
   setProjects: (projects: Project[]) => void;
   addProject: (project: Project) => void;
@@ -26,6 +29,9 @@ interface TaskState {
   addLabel: (label: Label) => void;
   updateLabel: (labelId: string, updates: Partial<Label>) => void;
   deleteLabel: (labelId: string) => void;
+  findLabelByName: (name: string) => Label | undefined;
+  findLabelById: (id: string) => Label | undefined;
+  findOrCreateLabel: (name: string, userId: string, defaultColor?: string) => Promise<Label>;
   
   setCurrentView: (view: ViewType, id?: string) => void;
   setFilter: (filter: Partial<TaskFilter>) => void;
@@ -41,18 +47,41 @@ export const useTaskStore = create<TaskState>((set, get) => ({
   loading: false,
 
   setTasks: (tasks) => set({ tasks }),
-  addTask: (task) => set({ tasks: [...get().tasks, task] }),
-  updateTask: (taskId, updates) => set({
-    tasks: get().tasks.map(task => 
-      task.id === taskId ? { ...task, ...updates } : task
-    )
-  }),
-  deleteTask: (taskId) => set({
-    tasks: get().tasks.filter(task => task.id !== taskId)
-  }),
+  addTask: async (task) => {
+    const sanitizedTaskData = Object.fromEntries(
+      Object.entries(task).filter(([key, value]) => {
+        return !['id', 'createdAt', 'updatedAt'].includes(key) && value !== undefined;
+      })
+    ) as Omit<Task, 'id' | 'createdAt' | 'updatedAt'>;
+
+    const newTaskId = await taskService.createTask(sanitizedTaskData);
+    const persistedTask = { ...task, id: newTaskId };
+
+    if (!get().tasks.some((existingTask) => existingTask.id === newTaskId)) {
+      set({ tasks: [...get().tasks, persistedTask] });
+    }
+  },
+  updateTask: async (taskId, updates) => {
+    await taskService.updateTask(taskId, updates);
+    set({
+      tasks: get().tasks.map((task) =>
+        task.id === taskId ? { ...task, ...updates, updatedAt: new Date() } : task
+      ),
+    });
+  },
+  deleteTask: async (taskId) => {
+    await taskService.deleteTask(taskId);
+    set({
+      tasks: get().tasks.filter((task) => task.id !== taskId),
+    });
+  },
 
   setProjects: (projects) => set({ projects }),
-  addProject: (project) => set({ projects: [...get().projects, project] }),
+  addProject: (project) => set({
+    projects: get().projects.some((existingProject) => existingProject.id === project.id)
+      ? get().projects
+      : [...get().projects, project],
+  }),
   updateProject: (projectId, updates) => set({
     projects: get().projects.map(project => 
       project.id === projectId ? { ...project, ...updates } : project
@@ -63,7 +92,11 @@ export const useTaskStore = create<TaskState>((set, get) => ({
   }),
 
   setLabels: (labels) => set({ labels }),
-  addLabel: (label) => set({ labels: [...get().labels, label] }),
+  addLabel: (label) => set({
+    labels: get().labels.some((existingLabel) => existingLabel.id === label.id)
+      ? get().labels
+      : [...get().labels, label],
+  }),
   updateLabel: (labelId, updates) => set({
     labels: get().labels.map(label => 
       label.id === labelId ? { ...label, ...updates } : label
@@ -72,6 +105,34 @@ export const useTaskStore = create<TaskState>((set, get) => ({
   deleteLabel: (labelId) => set({
     labels: get().labels.filter(label => label.id !== labelId)
   }),
+  findLabelByName: (name) => {
+    return get().labels.find((label) => label.name.toLowerCase() === name.toLowerCase());
+  },
+  findLabelById: (id) => {
+    return get().labels.find((label) => label.id === id);
+  },
+  findOrCreateLabel: async (name, userId, defaultColor = parserConfig.labels.defaultColor) => {
+    const existingLabel = get().findLabelByName(name);
+    if (existingLabel) {
+      return existingLabel;
+    }
+
+    const labelId = await labelService.createLabel({
+      name,
+      color: defaultColor,
+      userId,
+    });
+
+    const newLabel: Label = {
+      id: labelId,
+      name,
+      color: defaultColor,
+      userId,
+    };
+
+    get().addLabel(newLabel);
+    return newLabel;
+  },
 
   setCurrentView: (view, id) => set({ 
     currentView: view,

--- a/src/utils/taskInputParser.ts
+++ b/src/utils/taskInputParser.ts
@@ -1,0 +1,162 @@
+import { parserConfig } from '../config/parserConfig';
+
+export interface ParsedInput {
+  cleanTitle: string;
+  priority?: 1 | 2 | 3 | 4;
+  dueDate?: Date;
+  labels: string[];
+  detectedKeywords: {
+    priority?: string;
+    date?: string;
+    labels: string[];
+  };
+}
+
+export class TaskInputParser {
+  private static instance: TaskInputParser;
+
+  public static getInstance(): TaskInputParser {
+    if (!TaskInputParser.instance) {
+      TaskInputParser.instance = new TaskInputParser();
+    }
+
+    return TaskInputParser.instance;
+  }
+
+  public parseInput(input: string): ParsedInput {
+    let cleanTitle = input;
+    const detectedKeywords: ParsedInput['detectedKeywords'] = { labels: [] };
+    const result: ParsedInput = {
+      cleanTitle: input,
+      labels: [],
+      detectedKeywords,
+    };
+
+    const priorityResult = this.parsePriority(cleanTitle);
+    if (priorityResult.priority) {
+      result.priority = priorityResult.priority;
+      detectedKeywords.priority = priorityResult.keyword;
+      cleanTitle = priorityResult.cleanText;
+    }
+
+    const dateResult = this.parseDate(cleanTitle);
+    if (dateResult.date) {
+      result.dueDate = dateResult.date;
+      detectedKeywords.date = dateResult.keyword;
+      cleanTitle = dateResult.cleanText;
+    }
+
+    const labelResult = this.parseLabels(cleanTitle);
+    if (labelResult.labels.length > 0) {
+      result.labels = labelResult.labels;
+      detectedKeywords.labels = labelResult.keywords;
+      cleanTitle = labelResult.cleanText;
+    }
+
+    result.cleanTitle = cleanTitle.trim().replace(/\s+/g, ' ');
+    return result;
+  }
+
+  private parsePriority(input: string): {
+    priority?: 1 | 2 | 3 | 4;
+    keyword?: string;
+    cleanText: string;
+  } {
+    const matches = Array.from(input.matchAll(parserConfig.priority.pattern));
+
+    if (matches.length === 0) {
+      return { cleanText: input };
+    }
+
+    const match = matches[0];
+    const keyword = match[0].toLowerCase();
+    const priority = parserConfig.priority.keywords[keyword];
+
+    if (priority) {
+      return {
+        priority: priority as 1 | 2 | 3 | 4,
+        keyword: match[0],
+        cleanText: input.replace(match[0], '').trim(),
+      };
+    }
+
+    return { cleanText: input };
+  }
+
+  private parseDate(input: string): {
+    date?: Date;
+    keyword?: string;
+    cleanText: string;
+  } {
+    for (const [keyword, dateFactory] of Object.entries(parserConfig.dates.keywords)) {
+      const regex = new RegExp(`\\b${keyword}\\b`, 'gi');
+      const match = input.match(regex);
+
+      if (!match) {
+        continue;
+      }
+
+      const date = dateFactory();
+      if (date) {
+        return {
+          date,
+          keyword: match[0],
+          cleanText: input.replace(regex, '').trim(),
+        };
+      }
+    }
+
+    for (const pattern of parserConfig.dates.patterns) {
+      const matches = Array.from(input.matchAll(pattern.regex));
+
+      if (matches.length === 0) {
+        continue;
+      }
+
+      const match = matches[0];
+      const date = pattern.parser(match);
+      if (date) {
+        return {
+          date,
+          keyword: match[0],
+          cleanText: input.replace(match[0], '').trim(),
+        };
+      }
+    }
+
+    return { cleanText: input };
+  }
+
+  private parseLabels(input: string): {
+    labels: string[];
+    keywords: string[];
+    cleanText: string;
+  } {
+    const matches = Array.from(input.matchAll(parserConfig.labels.pattern));
+
+    if (matches.length === 0) {
+      return { labels: [], keywords: [], cleanText: input };
+    }
+
+    const labels: string[] = [];
+    const keywords: string[] = [];
+    let cleanText = input;
+
+    for (const match of matches) {
+      const labelName = match[1].toLowerCase();
+      if (!labels.includes(labelName)) {
+        labels.push(labelName);
+        keywords.push(match[0]);
+      }
+      cleanText = cleanText.replace(match[0], '').trim();
+    }
+
+    return {
+      labels,
+      keywords,
+      cleanText,
+    };
+  }
+}
+
+export const taskInputParser = TaskInputParser.getInstance();


### PR DESCRIPTION
## Summary
- forward-port the automatic label, priority, and due-date parsing flow from `feature/auto-label-parsing` onto current `main`
- switch the app from mock task data to realtime Firestore subscriptions and async store actions so parsed labels and new tasks persist correctly
- add mobile sidebar handling and touch-friendly task form updates from the feature branch
- replace the expired Firestore rules with flat-collection owner rules that match the current data model

## Why
The existing `feature/auto-label-parsing` branch is behind `main`, conflicts with the current Firebase setup, and assumes a different Firestore document layout. This PR preserves the user-facing parser behavior while keeping the current flat collection model intact.

## Validation
- `npm run lint`
- `npm run build`
- `(cd functions && npm run lint)`
- `(cd functions && npm run build)`
